### PR TITLE
Fix broken sitewide disclaimers, bump version number to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:**  
 **Requires at least:** 4.4  
 **Tested up to:**      4.9.7  
-**Stable tag:**        0.1.0  
+**Stable tag:**        0.1.1  
 **License:**           GPLv2 or later  
 **License URI:**       http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -18,16 +18,33 @@ This plugin derives from work done on the [Largo theme for WordPress](https://la
 
 ## Installation ##
 
+We recommend installing this plugin through the WordPress.org plugin repository via the WordPress dashboard. For more information about this process, [see the WordPress Codex article on managing plugins](https://codex.wordpress.org/Managing_Plugins).
+
 ### Manual Installation ###
 
-1. Upload the entire `/disclaimers` directory to the `/wp-content/plugins/` directory.
-2. Activate Disclaimers through the 'Plugins' menu in WordPress.
+0. Download this plugin from [WordPress.org's plugin repository](https://wordpress.org/plugins/disclaimers/) or [from the Disclaimers GitHub repository releases page](https://github.com/INN/disclaimers/releases/).
+1. Unzip the downloaded file and then upload the entire `/disclaimers` directory to your site's `/wp-content/plugins/` directory.
+2. Activate Disclaimers through the 'Plugins' menu in the WordPress dashboard, or with [`wp plugin activate disclaimers`](https://developer.wordpress.org/cli/commands/plugin/activate/).
 
-## Frequently Asked Questions ##
+## Frequently Asked Questions
+
+### Is this compatible with Largo?
+
+A future release of [the Largo theme](https://largo.inn.org/) will include compatibility for this plugin. That release will also remove Largo's own built-in disclaimers functionality in favor of this plugin's feature set. Existing per-post and sitewide disclaimers will continue to display, though you may need to replace the widgets on your site.
+
+## Screenshots
+
+For screenshots of this plugin in action, see [the release announcement blog post](https://labs.inn.org/2018/08/02/plugin-release-disclaimers/).
+
 
 ## Changelog ##
 
-### 0.1.0 ###
+### 0.1.1
+
+- Fixes a bug where the sitewide disclaimer would not show in the widget.
+- Fixes disclaimer/disclosure wording confusion
+
+### 0.1.0
 
 The first release of this plugin, containing:
 

--- a/disclaimers.php
+++ b/disclaimers.php
@@ -3,7 +3,7 @@
  * Plugin Name: Disclaimers
  * Plugin URI:  https://github.com/INN/disclaimers/
  * Description: A radical new plugin for WordPress!
- * Version:     0.1.0
+ * Version:     0.1.1
  * Author:      innlabs
  * Author URI:  https://labs.inn.org
  * Donate link: https://inn.org/donate/
@@ -14,7 +14,7 @@
  * @link    https://labs.inn.org
  *
  * @package Disclaimers
- * @version 0.1.0
+ * @version 0.1.1
  *
  * Built using generator-plugin-wp (https://github.com/WebDevStudios/generator-plugin-wp)
  */
@@ -61,7 +61,7 @@ final class Disclaimers {
 	 * @var    string
 	 * @since  0.1.0
 	 */
-	const VERSION = '0.1.0';
+	const VERSION = '0.1.1';
 
 	/**
 	 * Option key

--- a/includes/class-largo-disclaimer-widget.php
+++ b/includes/class-largo-disclaimer-widget.php
@@ -39,7 +39,7 @@ class largo_disclaimer_widget extends WP_Widget {
 		echo wp_kses_post( $args['before_widget'] );
 
 		$disclaimer = wp_kses_post( get_post_meta( get_the_ID(), 'disclaimer', true  ) );
-		$sitewide = wp_Kses_post(  get_option( 'disclaimer_default_disclaimer' ) );
+		$sitewide = wp_kses_post(  get_option( Disclaimers::OPTION_KEY ) );
 
 		if ( ! empty( $disclaimer ) ) {
 			echo $disclaimer;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "disclaimers",
 	"title": "Disclaimers",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "A radical new plugin for WordPress!",
 	"author": {
 		"name": "inn_nerds",

--- a/readme.txt
+++ b/readme.txt
@@ -5,37 +5,49 @@ Tags: disclaimer
 Requires at least: 4.9.6
 Tested up to: 4.9.7
 Requires PHP: 5.6
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Display disclaimers for posts or your whole site using a handy widget.
 
-## Description ##
+== Description ==
 
 This plugin implements a widget allowing you to display disclaimers. Disclaimers can be set on a site-wide basis or on a per-post basis, with per-post disclaimers overriding site-wide disclaimers.
 
 This plugin derives from work done on the [Largo theme for WordPress](https://largo.inn.org/). We've taken a small portion of Largo's functionality and made it accessible to all WordPress sites.
 
-## Installation ##
+== Installation ==
 
-### Manual Installation ###
+We recommend installing this plugin through the WordPress.org plugin repository via the WordPress dashboard. For more information about this process, [see the WordPress Codex article on managing plugins](https://codex.wordpress.org/Managing_Plugins).
 
-1. Upload the entire `/disclaimers` directory to the `/wp-content/plugins/` directory.
-2. Activate Disclaimers through the 'Plugins' menu in WordPress.
+= Manual Installation =
 
-## Frequently Asked Questions ##
+0. Download this plugin from [WordPress.org's plugin repository](https://wordpress.org/plugins/disclaimers/) or [from the Disclaimers GitHub repository releases page](https://github.com/INN/disclaimers/releases/).
+1. Unzip the downloaded file and then upload the entire `/disclaimers` directory to your site's `/wp-content/plugins/` directory.
+2. Activate Disclaimers through the 'Plugins' menu in the WordPress dashboard, or with [`wp plugin activate disclaimers`](https://developer.wordpress.org/cli/commands/plugin/activate/).
 
+== Frequently Asked Questions ==
 
-## Screenshots ##
+= Is this compatible with Largo? =
 
+A future release of [the Largo theme](https://largo.inn.org/) will include compatibility for this plugin. That release will also remove Largo's own built-in disclaimers functionality in favor of this plugin's feature set. Existing per-post and sitewide disclaimers will continue to display, though you may need to replace the widgets on your site.
 
-## Changelog ##
+== Screenshots ==
 
-### 0.1.0 ###
+For screenshots of this plugin in action, see [the release announcement blog post](https://labs.inn.org/2018/08/02/plugin-release-disclaimers/).
+
+== Changelog ==
+
+= 0.1.1 =
+
+- Fixes a bug where the sitewide disclaimer would not show in the widget.
+- Fixes disclaimer/disclosure wording confusion
+
+= 0.1.0 =
 
 The first release of this plugin, containing:
 
-* Site-wide standard disclosure settings in the site's **Settings > Disclosures** menu entry
-* Per-post disclosure settings
-* A widget to display each post's disclosures
+* Site-wide standard disclaimer settings in the site's **Settings > Disclaimers** menu entry
+* Per-post disclaimer settings
+* A widget to display each post's disclaimer


### PR DESCRIPTION
Changes:

- Makes the widget use the correct option key
- Updates the version number to 0.1.1
- Links to screenshots in tomorrow's blog post